### PR TITLE
workflow: run ci for mac-os

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ mainline ]
 
 jobs:
-  build:
+  build-ubuntu:
     runs-on: ubuntu-latest
     steps:
     - name: Install Required Packages
@@ -16,6 +16,18 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y qemu qemu-user
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: ./tools/ci/build-docker.sh
+    - name: Run the Docker image
+      run: ./tools/ci/launch-test.sh
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - name: Install Required Packages
+      run: |
+            brew install qemu docker
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: ./tools/ci/build-docker.sh


### PR DESCRIPTION
To make sure we do not break the basics for the diverse user base,
enable CI for mac os as well.

Signed-off-by: Norbert Manthey <nmanthey@amazon.de>

*Issue #, if available:*

*Description of changes:*

Enable CI for macos as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
